### PR TITLE
Save checked metrics on settings

### DIFF
--- a/src/app/exportPage.js
+++ b/src/app/exportPage.js
@@ -1,7 +1,7 @@
 var ExportPage = (function () {
 
     const settings = new AppSettings();
-    const metricCongig = new ReportMetricConfig();
+    const metricConfig = new ReportMetricConfig();
     const cache = settings.get('useReportCache') ? new MemoryCache() : undefined;
 
     const init = function (endpoint, testCode) {
@@ -54,18 +54,28 @@ var ExportPage = (function () {
         });
     }
 
-    const onMetricMoved = function () {
+    const onMetricMoved = () => {
+        setMetricsState();
+    }
+
+    const onMetricChange = () => {
+        setMetricsState();
+    }
+
+    const setMetricsState = () => {
         var metrics = getExportMetrics(i => true);
 
-        metricCongig.setOrder(metrics);
+        metricConfig.setMetricsState(metrics);
     }
 
     const getExportMetrics = function (filterCallback) {
         let metricInputs = FormHelper.getInputs('metrics');
-
+        
         filterCallback = filterCallback || (i => i.checked);
-
-        return Array.from(metricInputs).filter(filterCallback).map((i) => i.value);
+        
+        return Array.from(metricInputs).filter(filterCallback).map((i) => { 
+            return { name: i.value, selected: i.checked }
+        });
     }
 
     const getFilters = function () {
@@ -117,7 +127,7 @@ var ExportPage = (function () {
     const renderMetricsSelector = function () {
         let metricSelector = document.getElementById('metricSelector');
 
-        metricCongig.list()
+        metricConfig.list()
             .filter(metric => metric.visible)
             .forEach(metric => HtmlHelper.insertBeforeEnd(metricSelector, Template.render('metricCheckbox', metric)));
     }
@@ -128,6 +138,7 @@ var ExportPage = (function () {
         document.getElementById('aggregate').addEventListener('change', onAggregationChange);
 
         UIkit.util.on('#metricSelector', 'moved', onMetricMoved);
+        UIkit.util.on('#metricSelector', 'change', onMetricChange);
     }
 
     return {

--- a/src/js/ReportMetricConfig.js
+++ b/src/js/ReportMetricConfig.js
@@ -1,4 +1,5 @@
 var ReportMetricConfig = function () {
+    const METRICS_STATE_KEY = 'metricsState';
 
     const appSettings = new AppSettings();
 
@@ -194,7 +195,7 @@ var ReportMetricConfig = function () {
 
     const init = function () {
         metrics.forEach(metric => metric.evaluate = jsonata(metric.expression).evaluate);
-        order();
+        setState();
 
         numberFormatDigits = parseInt(appSettings.get('formatNumberDigits'))
     }
@@ -203,19 +204,21 @@ var ReportMetricConfig = function () {
 
     const list = () => metrics;
 
-    const setOrder = function (metricOrder) {
-        appSettings.set('metricOrder', metricOrder);
-        order(metricOrder);
+    const setMetricsState = function (metricState) {
+        appSettings.set(METRICS_STATE_KEY, metricState);
+        setState(metricState);
     }
 
-    const order = function (metricOrder) {
-        metricOrder = metricOrder || appSettings.get('metricOrder');
-        metricOrder && metrics.sort((m1, m2) => {
-            let mi1 = metricOrder.indexOf(m1.name),
-                mi2 = metricOrder.indexOf(m2.name);
+    const setState = function (metricState) {
+        metricState = metricState || appSettings.get(METRICS_STATE_KEY);
+        metricState && metrics.sort((m1, m2) => {
+            let mi1 = metricState.findIndex(e => e.name === m1.name),
+                mi2 = metricState.findIndex(e => e.name === m2.name);
 
             return mi1 - mi2;
         });
+
+        metricState && metrics.forEach((metric, index) => metric.checked = metricState[index].selected);
     }
 
     init();
@@ -223,6 +226,6 @@ var ReportMetricConfig = function () {
     return {
         get,
         list,
-        setOrder,
+        setMetricsState,
     }
 }

--- a/src/options_page/i18n.js
+++ b/src/options_page/i18n.js
@@ -60,5 +60,11 @@ this.i18n = {
     },
     "wptResult": {
         "en": "WPT Result",
+    },
+    "resetChecked": {
+        "en": "Reset Checked"
+    },
+    "checked": {
+        "en": "Checked"
     }
 };

--- a/src/options_page/settings.js
+++ b/src/options_page/settings.js
@@ -31,6 +31,14 @@ window.addEvent("domready", function () {
         text: i18n.get("resetOrder")
     });
 
+    let resetMetricCheckedButton = settings.create({
+        tab: i18n.get("metrics"),
+        group: i18n.get("checked"),
+        name: "resetMetricChecked",
+        type: "button",
+        text: i18n.get("resetChecked")
+    })
+
     // CACHE
     settings.create({
         tab: i18n.get("server"),
@@ -61,5 +69,9 @@ window.addEvent("domready", function () {
 
     resetMetricOrderButton.addEvent('action', function () {
         appSettings.set('metricOrder', undefined);
+    });
+
+    resetMetricCheckedButton.addEvent('action', function() {
+        appSettings.set('metricChecked', undefined);
     });
 });


### PR DESCRIPTION
Save checked metrics on settings in order to be able to load them when extension in started.

This way the user do not need to change the metrics preferences every time he starts the extension